### PR TITLE
Update to 1.20 (alternative option)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.0.7'
+    id 'fabric-loom' version '1.3.+'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.19.2
-yarn_mappings=1.19.2+build.11
-loader_version=0.14.9
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.10
+loader_version=0.14.22
 
 # Mod Properties
-mod_version = 1.5.0
+mod_version = 1.6.0
 maven_group = leaf-decay
 archives_base_name = leaf-decay
 
 # Dependencies
-fabric_version=0.60.0+1.19.2
-cloth_config_version = 7.0.72
-mod_menu_version = 4.0.0
+fabric_version=0.90.4+1.20.1
+cloth_config_version = 11.1.106
+mod_menu_version = 7.2.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/draylar/leafdecay/mixin/LogBreakMixin.java
+++ b/src/main/java/draylar/leafdecay/mixin/LogBreakMixin.java
@@ -4,7 +4,9 @@ import draylar.leafdecay.scheduler.FutureBlockBreak;
 import draylar.leafdecay.scheduler.LeafBreakHandler;
 import net.minecraft.block.*;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -20,7 +22,7 @@ public class LogBreakMixin {
             at = @At("TAIL")
     )
     private void afterBreak(World world, BlockPos pos, BlockState state, PlayerEntity player, CallbackInfo info) {
-        if (!world.isClient && (state.getBlock() instanceof PillarBlock) && state.getMaterial().equals(Material.WOOD)) {
+        if (!world.isClient && (state.getBlock() instanceof PillarBlock) && state.isIn(BlockTags.LOGS)) {
             BlockPos upPosition = pos.up();
             BlockState upState = world.getBlockState(upPosition);
 

--- a/src/main/java/draylar/leafdecay/mixin/LogBreakMixin.java
+++ b/src/main/java/draylar/leafdecay/mixin/LogBreakMixin.java
@@ -6,7 +6,6 @@ import net.minecraft.block.*;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/java/draylar/leafdecay/scheduler/FutureBlockBreak.java
+++ b/src/main/java/draylar/leafdecay/scheduler/FutureBlockBreak.java
@@ -2,15 +2,9 @@ package draylar.leafdecay.scheduler;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.item.ItemStack;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.ItemScatterer;
-import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-
-import java.util.List;
 
 /**
  * Provides information about a block that should break in the future.
@@ -45,19 +39,14 @@ public class FutureBlockBreak {
      * <p>The block broken will drop stacks as normal.
      */
     public void realize() {
-        BlockState state = world.getBlockState(pos);
-        world.setBlockState(pos, Blocks.AIR.getDefaultState());
-
-        if (!world.isClient) {
-            List<ItemStack> drops = Block.getDroppedStacks(state, world, pos, null);
-            DefaultedList<ItemStack> defaultedDropList = DefaultedList.ofSize(drops.size(), ItemStack.EMPTY);
-
-            for (int i = 0; i < drops.size(); i++) {
-                defaultedDropList.set(i, drops.get(i));
-            }
-
-            ItemScatterer.spawn(world, pos, defaultedDropList);
+        if (world.isClient) {
+            return;
         }
+
+        BlockState state = world.getBlockState(pos);
+
+        Block.dropStacks(state, world, pos);
+        world.removeBlock(pos, false);
     }
 
     public int getElapsedTime() {

--- a/src/main/java/draylar/leafdecay/scheduler/LeafBreakHandler.java
+++ b/src/main/java/draylar/leafdecay/scheduler/LeafBreakHandler.java
@@ -4,35 +4,32 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.LeavesBlock;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.Pair;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 public class LeafBreakHandler {
-
-    private static final ArrayList<FutureBlockBreak> breakList = new ArrayList<>();
+    private static final ArrayList<FutureBlockBreak> BREAK_LIST = new ArrayList<>();
 
     public static void init() {
         ServerTickEvents.END_SERVER_TICK.register(tick -> {
             List<FutureBlockBreak> nearbyFutureBreakOrigins = new ArrayList<>();
 
-            for(Iterator<FutureBlockBreak> iterator = breakList.iterator(); iterator.hasNext();) {
+            for (Iterator<FutureBlockBreak> iterator = BREAK_LIST.iterator(); iterator.hasNext();) {
                 FutureBlockBreak leafBreak = iterator.next();
-                // should be broken
-                if (leafBreak.getElapsedTime() >= leafBreak.getMaxTime()) {
+                int elapsed = leafBreak.getElapsedTime();
+
+                if (elapsed >= leafBreak.getMaxTime()) {
+                    // should be broken
                     leafBreak.realize();
                     iterator.remove();
                     nearbyFutureBreakOrigins.add(leafBreak);
-                }
-
-                // increment time
-                else {
-                    leafBreak.setElapsedTime(leafBreak.getElapsedTime() + 1);
+                } else {
+                    // increment time
+                    leafBreak.setElapsedTime(elapsed + 1);
                 }
             }
 
@@ -48,9 +45,12 @@ public class LeafBreakHandler {
             BlockState newState = world.getBlockState(offset);
 
             // ensure new position is a leaf and that the break list doesn't already contain it
-            if (newState.getBlock() instanceof LeavesBlock && !breakListContains(offset)) {
+            if (!breakListContains(offset) &&
+                    world.getBlockState(offset).getBlock() instanceof LeavesBlock leavesBlock) {
+
                 // if the leaf would naturally decay, add it to the break list
-                if (!newState.get(LeavesBlock.PERSISTENT) && newState.get(LeavesBlock.DISTANCE) == 7) {
+                // (hasRandomTicks() is identical to shouldDecay() but is public without an access widener)
+                if (leavesBlock.hasRandomTicks(newState)) {
                     LeafBreakHandler.addFutureBreak(new FutureBlockBreak(world, offset, 5));
                 }
             }
@@ -58,8 +58,8 @@ public class LeafBreakHandler {
     }
 
     private static boolean breakListContains(BlockPos offset) {
-        for(FutureBlockBreak futureBreak : breakList) {
-            if(futureBreak.getPos().equals(offset)) {
+        for (FutureBlockBreak futureBreak : BREAK_LIST) {
+            if (futureBreak.getPos().equals(offset)) {
                 return true;
             }
         }
@@ -69,6 +69,6 @@ public class LeafBreakHandler {
 
 
     public static void addFutureBreak(FutureBlockBreak futureBreak) {
-        breakList.add(futureBreak);
+        BREAK_LIST.add(futureBreak);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,4 +1,3 @@
-
 {
   "schemaVersion": 1,
   "id": "leaf-decay",
@@ -29,7 +28,7 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.7.0",
-    "fabric": ">=0.14.0"
+    "fabricloader": ">=0.13.3",
+    "fabric-api": "*"
   }
 }


### PR DESCRIPTION
This PR makes minimal changes in order to be as easy as possible to merge.  However, the main reason I've created this PR is PR #26 will only work with vanilla logs.  In that sense, this is a more correct implementation (as much as is possible since Material was removed).  Instead of hard-coding some vanilla log types, this PR uses the `minecraft:logs` block tag, which must work for any mod using vanilla's LeavesBlock without significant modification, because that is the tag used in vanilla decay.

It is possible some mods with a custom leaves implementation may not work (may not add their logs to `minecraft:logs`), but I did not find any such mods in a brief survey of major Fabric biome mods.  I don't think we need to worry about this, but if you want an implementation that should work in roughly any case the Material-based implementation did, the following is fairly equivalent.  (I've noticed some mods seem to take a lot of liberties in their mapping of block sound group to wood type, so this doesn't assume bamboo isn't used for real logs or nether can't be a tree with leaves.)

```java
    private void afterBreak(World world, BlockPos pos, BlockState state, PlayerEntity player, CallbackInfo info) {
        if (!world.isClient && (state.getBlock() instanceof PillarBlock)) {
            BlockSoundGroup soundGroup = state.getSoundGroup();
            if (state.isIn(BlockTags.LOGS) ||
                    BlockSoundGroup.WOOD.equals(soundGroup) ||
                    BlockSoundGroup.NETHER_WOOD.equals(soundGroup) ||
                    BlockSoundGroup.CHERRY_WOOD.equals(soundGroup) ||
                    BlockSoundGroup.BAMBOO_WOOD.equals(soundGroup)) {
// ...
```